### PR TITLE
Update to environment_credentials.js for legacy container support

### DIFF
--- a/lib/credentials/environment_credentials.js
+++ b/lib/credentials/environment_credentials.js
@@ -63,13 +63,16 @@ AWS.EnvironmentCredentials = AWS.util.inherit(AWS.Credentials, {
       return;
     }
 
-    var keys = ['ACCESS_KEY_ID', 'SECRET_ACCESS_KEY', 'SESSION_TOKEN'];
+    var keys = [['ACCESS_KEY_ID', 'ACCESS_KEY'], ['SECRET_ACCESS_KEY', 'SECRET_KEY'], 'SESSION_TOKEN'];
     var values = [];
 
     for (var i = 0; i < keys.length; i++) {
       var prefix = '';
       if (this.envPrefix) prefix = this.envPrefix + '_';
-      values[i] = process.env[prefix + keys[i]];
+      if (Array.isArray(keys[i])) 
+        values[i] = process.env[prefix + keys[i][0]] || process.env[prefix + keys[i][1]];
+      else 
+        values[i] = process.env[prefix + keys[i]]; 
       if (!values[i] && keys[i] !== 'SESSION_TOKEN') {
         callback(new Error('Variable ' + prefix + keys[i] + ' not set.'));
         return;


### PR DESCRIPTION
Added support for [PREFIX_]ACCESS_KEY and [PREFIX_]SECRET_KEY to support ElasticBeanstalk Console immutable environment parameter names and other legacy container configurations.

See https://github.com/aws/aws-sdk-js/issues/571 for details.
